### PR TITLE
Fix merging definitions

### DIFF
--- a/kubepy/definition_merger.py
+++ b/kubepy/definition_merger.py
@@ -1,3 +1,4 @@
+from collections import abc
 import itertools
 import functools
 
@@ -22,7 +23,7 @@ def merge_lists(*definitions):
     named_results = {}
     unmerged_results = []
     for definition in itertools.chain(*definitions):
-        if hasattr(definition, '__getitem__') and 'name' in definition:
+        if isinstance(definition, abc.Mapping) and 'name' in definition:
             name = definition['name']
             if name in named_results:
                 named_results[name].append(definition)


### PR DESCRIPTION
When string had substring "name" in it, it was treated as dictionary, causing an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/kubepy/26)
<!-- Reviewable:end -->
