### PR TITLE
Add support for ConfigMap

### DIFF
--- a/kubepy/api.py
+++ b/kubepy/api.py
@@ -77,7 +77,7 @@ def replace(definition, namespace=None):
 
 def rolling_update(definition, name, namespace=None):
     command = kubectl_command_builder('rolling-update', name=name, namespace=namespace, with_definition=True)
-    run_command_with_yaml_on_stdin(command,definition)
+    run_command_with_yaml_on_stdin(command, definition)
 
 
 def delete(kind, name, namespace=None):

--- a/kubepy/appliers.py
+++ b/kubepy/appliers.py
@@ -85,7 +85,7 @@ class BaseDefinitionApplier:
 
 
 class ResourceApplier(BaseDefinitionApplier):
-    usable_with = ['Service', 'Secret', 'StorageClass', 'PersistentVolume',
+    usable_with = ['Service', 'Secret', 'ConfigMap', 'StorageClass', 'PersistentVolume',
                    'PersistentVolumeClaim', 'Ingress', 'PodDisruptionBudget']
 
     def apply(self):

--- a/kubepy/appliers.py
+++ b/kubepy/appliers.py
@@ -252,7 +252,8 @@ class JobApplier(BaseJobApplier):
     status_class = JobStatus
 
     def _get_status(self):
-        return self.status_class(self.name, self._get_raw_status(), self.options.max_job_retries, namespace=self.namespace)
+        return self.status_class(self.name, self._get_raw_status(), self.options.max_job_retries,
+                                 namespace=self.namespace)
 
 
 class PodApplier(BaseJobApplier):


### PR DESCRIPTION
Hey! 
I wanted to use `ConfigMap` instead of `Secret` for non-confidential data, but it turned out that kubepy currently does not support it, but it can be easilly added by extending `ResourceApplier.usable_with` with `ConfigMap`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/kubepy/35)
<!-- Reviewable:end -->
