### PR TITLE
Enable overriding dict type fields with null

### DIFF
--- a/kubepy/definition_merger.py
+++ b/kubepy/definition_merger.py
@@ -11,10 +11,16 @@ def merge_definitions(*definitions):
 
 @merge_definitions.register(dict)
 def merge_dicts(*definitions):
-    keys = set(itertools.chain(*(definition.keys() for definition in definitions)))
+    if definitions[-1] is None:
+        return None
+    keys = set(itertools.chain(*(definition.keys() for definition in definitions if definition is not None)))
     result = {}
     for key in keys:
-        result[key] = merge_definitions(*(definition[key] for definition in definitions if key in definition))
+        value = merge_definitions(
+            *(definition[key] for definition in definitions if definition is not None and key in definition)
+        )
+        if value is not None:
+            result[key] = value
     return result
 
 


### PR DESCRIPTION
### Current behavior

Currently, `kubepy` does not support merging configurations when initial configuration defines field as dictionary and another configuration is intended to unset the field, e.g. by setting null.  In such case `kubepy` hits fatal error, because it tries to iterate over the keys of the field, no matter what's the value from overriding configuration.

### Intended behavior

So let's say, we have `env` item with `valueFrom` dictionary  field:

***deploy/example_deployment.yml***
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: example-deployment
spec:
  template:
    spec:
      containers:
      - name: example-container
        image: debian
        env:
        - name: EXAMPLE_SECRET
          valueFrom:
            secretKeyRef:
              name: example-secerts
              key: example-field
```

Now, this would be the way to unset `valueFrom` and set `value` instead:

***development_overrides/example_deployment.yml***
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: test-deployment
spec:
  template:
    spec:
      containers:
      - name: example-container
        env:
        - name: EXAMPLE_SECRET
          valueFrom: null
          value: example-dev-value
```

### Consistency with related tools/solutions 


Proposed feature is consistent with the way [helm merges values](https://github.com/helm/helm/blob/v2.16.0/docs/chart_template_guide/values_files.md#deleting-a-default-key).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/kubepy/36)
<!-- Reviewable:end -->
